### PR TITLE
Open orders API

### DIFF
--- a/routes/orderRoutes.js
+++ b/routes/orderRoutes.js
@@ -247,4 +247,30 @@ app.patch('/:id/unclaim', isAuthenticated, async (req, res) => {
     }
 })
 
+// Route to fetch open orders for a user
+app.get('/open', isAuthenticated, async (req, res) => {
+    try {
+        const userID = req.session.userId
+
+        const openOrders = await Order.find({
+            $or: [{ buyer: userID }, { seller: userID }]
+        }).lean()
+
+        res.status(200).json({
+            orders: openOrders.map((order) => {
+                const isBuy = order.buyer.toString() === userID
+                order.type = isBuy ? 'buy' : 'sell'
+                delete order.buyer
+                delete order.seller
+                return order
+            })
+        })
+    } catch (err) {
+        console.log(err)
+        res.status(500).json({
+            message: 'Internal server error'
+        })
+    }
+})
+
 module.exports = app


### PR DESCRIPTION
Adds a `GET /orders/open` route to fetch all orders that are currently open for a given user. This assumes that the orders collection only contains open orders, which is not currently the case, but will be after we add a cron job process to periodically move completed orders to some sort of separate archival collection in MongoDB.