### PR TITLE
API to delete a user

### DIFF
--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -4,6 +4,7 @@ const express = require('express')
 const emailClient = require('../services/emailClient')
 const stripeClient = require('../services/stripeClient')
 const User = require('../models/user')
+const { isAuthenticated } = require('../utils/authUtils')
 
 const app = express()
 dotenv.config()
@@ -111,7 +112,7 @@ app.post('/login', async (req, res) => {
 })
 
 // Logout route
-app.post('/logout', (req, res) => {
+app.post('/logout', isAuthenticated, (req, res) => {
     req.session.destroy((err) => {
         if (err) {
             console.log(err)


### PR DESCRIPTION
- Add a `DELETE /profile` API that deletes a user's profile. It prevents this action from occurring if they have open orders, because that's a lot to handle and I'd rather not have to mess with that.
- Require that a user be authenticated for the `POST /auth/logout` route.