### PR TITLE
Payment method setup

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -5,5 +5,8 @@
     "editor.formatOnSave": true,
     "editor.formatOnSaveMode": "file",
     "files.autoSave": "onFocusChange",
-    "vs-code-prettier-eslint.prettierLast": false // set as "true" to run 'prettier' last not first
+    "vs-code-prettier-eslint.prettierLast": false,
+    "editor.codeActionsOnSave": {
+        "source.organizeImports.biome": "explicit"
+    }
 }

--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ Install the following required VSCode extensions.
 -   ESLint
 -   Prettier
 -   Prettier ESLint
+-   Biome
+-   SonarQube
 
 Optionally, install the following recommended VSCode extensions.
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,3 @@
+{
+    "formatter": { "enabled": false }
+}

--- a/models/user.js
+++ b/models/user.js
@@ -1,10 +1,25 @@
 const bcrypt = require('bcrypt')
 const mongoose = require('mongoose')
 
-const OrderSchema = new mongoose.Schema({
-    id: { type: mongoose.Schema.Types.ObjectId, ref: 'Order', required: true },
-    type: { type: String, required: true }
-})
+const OrderSchema = new mongoose.Schema(
+    {
+        id: {
+            type: mongoose.Schema.Types.ObjectId,
+            ref: 'Order',
+            required: true
+        },
+        type: { type: String, required: true }
+    },
+    { _id: false }
+)
+
+const PaymentMethodSchema = new mongoose.Schema(
+    {
+        id: { type: String, required: true },
+        default: { type: Boolean, required: true }
+    },
+    { _id: false }
+)
 
 const UserSchema = new mongoose.Schema({
     email: {
@@ -22,7 +37,7 @@ const UserSchema = new mongoose.Schema({
         required: true,
         minlength: 8,
         validate: {
-            validator: function (v) {
+            validator: (v) => {
                 // Regular expression for the password criteria:
                 // - At least one digit
                 // - At least one lowercase letter
@@ -33,7 +48,8 @@ const UserSchema = new mongoose.Schema({
                     v
                 )
             },
-            message: `Password must be at least 8 characters long and include at least one number, one uppercase letter, one lowercase letter, and one special character (! @ # $ % ^ & *).`
+            message:
+                'Password must be at least 8 characters long and include at least one number, one uppercase letter, one lowercase letter, and one special character (! @ # $ % ^ & *).'
         }
     },
     firstName: {
@@ -52,7 +68,8 @@ const UserSchema = new mongoose.Schema({
     resetPasswordToken: String, // Store the reset token
     resetPasswordExpires: Date, // Expiry time for the reset token
     openOrders: [OrderSchema], // Array of open orders
-    paymentSetupIntent: String // Store the stripe payment setup intent
+    paymentSetupIntent: String, // Store the stripe payment setup intent
+    paymentMethods: [PaymentMethodSchema] // Array of payment methods
 })
 
 // Hash the password before saving the user document

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -1,4 +1,4 @@
-const crypto = require('crypto')
+const crypto = require('node:crypto')
 const dotenv = require('dotenv')
 const express = require('express')
 const emailClient = require('../services/emailClient')
@@ -34,17 +34,10 @@ app.post('/signup', async (req, res) => {
         const isVerified = process.env.ENVIRONMENT === 'dev' // Automatically verify user in dev environment
         const verificationToken = crypto.randomBytes(32).toString('hex')
 
-        const stripeCustomer = await stripeClient.customers.create({
+        await stripeClient.customers.create({
             email: email.toLowerCase(),
             name: `${firstName} ${lastName}`
         })
-
-        const setupIntent = await stripeClient.setupIntents.create({
-            customer: stripeCustomer.id,
-            payment_method_types: ['card']
-        })
-
-        const paymentSetupIntent = setupIntent.client_secret
 
         await User.create({
             email,
@@ -52,8 +45,7 @@ app.post('/signup', async (req, res) => {
             firstName,
             lastName,
             isVerified,
-            verificationToken,
-            paymentSetupIntent
+            verificationToken
         })
 
         await sendVerificationEmail(email, verificationToken)

--- a/routes/orderRoutes.js
+++ b/routes/orderRoutes.js
@@ -260,8 +260,8 @@ app.get('/open', isAuthenticated, async (req, res) => {
             orders: openOrders.map((order) => {
                 const isBuy = order.buyer.toString() === userID
                 order.type = isBuy ? 'buy' : 'sell'
-                delete order.buyer
-                delete order.seller
+                order.buyer = undefined
+                order.seller = undefined
                 return order
             })
         })

--- a/routes/profileRoutes.js
+++ b/routes/profileRoutes.js
@@ -10,7 +10,7 @@ app.get('/', isAuthenticated, async (req, res) => {
     try {
         const user = await User.findById(
             req.session.userId,
-            'firstName lastName email paymentSetupIntent openOrders'
+            'firstName lastName email paymentSetupIntent openOrders paymentMethods'
         )
         if (!user) {
             return res.status(404).json({


### PR DESCRIPTION
- Perform some cleanup based on the "biome" code-linting tool
- Change payment setup process such that the setup intent is generated when needed, rather than at account creation
- Store payment method information in the DB (just `id` and `default` properties - everything else is in stripe)
- Pass payment methods instead of payment setup intent as part of `GET /profile`
- Completely rewrite `/payment` with the following routes:
    - `GET /setup-intent` that fetches the stripe information necessary to add a payment method on the frontend side
    - `DELETE /setup-intent` that clears the setup intent, adds the new payment method to mongo, & returns the updated list of payment methods
    - `GET /customer` that returns all relevant stripe information about the user
    - `PATCH /default-method/:id` that sets the default payment method to the given ID & returns the updated list of payment methods
    - `DELETE /:id` that deletes the specified payment method & returns the updated list of payment methods