### PR TITLE
Handle requests from website links

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ touch .env
 
 Open the newly created `.env` file and enter all needed environment variables, listed below.
 
--   `CLIENT_URL`: The URL of the frontend application
+-   `CLIENT_URL`: The URL of the frontend application.
 -   `DB_USERNAME`: The username the application will use to connect to the database.
 -   `DB_PASSWORD`: The corresponding password for `DB_USERNAME`.
 -   `DB_CLUSTER_URL`: The URL of the database cluster. This is what comes after the "@" but before the query parameters in the full connection URL.
@@ -63,6 +63,7 @@ Open the newly created `.env` file and enter all needed environment variables, l
 -   `PORT`: The port the application will run on (optional, defaults to `3000`).
 -   `SESSION_SECRET`: The string used to encode session data.
 -   `STRIPE_SECRET_KEY`: The client secret that will be used to login to [Stripe](https://dashboard.stripe.com).
+-   `WEBSITE_URL`: The URL of the [project's website](https://github.com/meal-match/website).
 
 ### Start the app
 

--- a/models/user.js
+++ b/models/user.js
@@ -74,7 +74,8 @@ const UserSchema = new mongoose.Schema({
     openOrders: [OrderSchema], // Array of open orders
     paymentSetupIntent: String, // Store the stripe payment setup intent
     pushToken: String, // Store the push notification token from the frontend
-    stripeAccountId: String // Store the stripe account ID
+    stripeAccountId: String, // Store the stripe account ID
+    stripeRefreshToken: String // Store the stripe refresh token
 })
 
 // Hash the password before saving the user document

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -17,7 +17,7 @@ const sendVerificationEmail = async (email, firstName, verificationToken) => {
         firstName,
         description:
             'Please click the link below to verify your email address:',
-        url: `${process.env.WEBSITE_URL}/auth/verify?token=${verificationToken}`,
+        url: `${process.env.WEBSITE_URL}/auth/verifyEmail?token=${verificationToken}`,
         linkText: 'Verify Email'
     })
 

--- a/routes/authRoutes.js
+++ b/routes/authRoutes.js
@@ -9,19 +9,31 @@ const { isAuthenticated } = require('../utils/authUtils')
 const app = express()
 dotenv.config()
 
-const sendVerificationEmail = async (email, verificationToken) => {
-    const subject = 'Verify Email'
-    const html = `
-            <p>You are receiving this because you (or someone else) have signed up for a MealMatch account. Click the link below to verify your email:</p>
-            <a href="${process.env.CLIENT_URL}/auth/verifyEmail?token=${verificationToken}">Verify Email</a>
-            <p>If you cannot click the link above, copy and paste the following URL into your browser:</p>
-            <p>${process.env.CLIENT_URL}/auth/verifyEmail?token=${verificationToken}</p>`
-    await emailClient.sendEmail({ to: email, subject, html })
+const sendVerificationEmail = async (email, firstName, verificationToken) => {
+    const subject = 'Verify Your MealMatch Account'
+
+    const { html, text } = emailClient.buildEmail({
+        header: 'Welcome to MealMatch!',
+        firstName,
+        description:
+            'Please click the link below to verify your email address:',
+        url: `${process.env.WEBSITE_URL}/auth/verify?token=${verificationToken}`,
+        linkText: 'Verify Email'
+    })
+
+    await emailClient.sendEmail({
+        to: email,
+        subject,
+        html,
+        text
+    })
 }
 
 // Sign up route
 app.post('/signup', async (req, res) => {
-    const { email, password, firstName, lastName } = req.body
+    const { password, firstName, lastName } = req.body
+    let { email } = req.body
+    email = email.toLowerCase()
 
     try {
         const user = await User.findOne({ email })
@@ -35,7 +47,7 @@ app.post('/signup', async (req, res) => {
         const verificationToken = crypto.randomBytes(32).toString('hex')
 
         await stripeClient.customers.create({
-            email: email.toLowerCase(),
+            email,
             name: `${firstName} ${lastName}`
         })
 
@@ -48,7 +60,7 @@ app.post('/signup', async (req, res) => {
             verificationToken
         })
 
-        await sendVerificationEmail(email, verificationToken)
+        await sendVerificationEmail(email, firstName, verificationToken)
 
         res.status(201).json({
             message:
@@ -79,7 +91,11 @@ app.post('/login', async (req, res) => {
 
         if (isMatch) {
             if (!user.isVerified) {
-                await sendVerificationEmail(email, user.verificationToken)
+                await sendVerificationEmail(
+                    email,
+                    user.firstName,
+                    user.verificationToken
+                )
                 return res.status(403).json({
                     message:
                         "Your email is not verified. We've resent an email with a verification link."
@@ -137,7 +153,10 @@ app.post('/send-reset', async (req, res) => {
     const { email } = req.body
 
     try {
-        const user = await User.findOne({ email })
+        const user = await User.findOne(
+            { email },
+            'firstName resetPasswordToken resetPasswordExpires'
+        )
 
         if (!user) {
             return res.status(401).json({
@@ -153,12 +172,14 @@ app.post('/send-reset', async (req, res) => {
 
         // Send email with password reset link
         const subject = 'Password Reset'
-        const html = `
-            <p>You are receiving this because you (or someone else) have requested the reset of the password for your account. Click the link below to reset your password:</p>
-            <a href="${process.env.CLIENT_URL}/auth/resetPassword?token=${token}">Reset Password</a>
-            <p>If you cannot click the link above, copy and paste the following URL into your browser:</p>
-            <p>${process.env.CLIENT_URL}/auth/resetPassword?token=${token}</p>`
-        await emailClient.sendEmail({ to: email, subject, html })
+        const { html, text } = emailClient.buildEmail({
+            header: 'Password Reset',
+            firstName: user.firstName,
+            description: 'Click the link below to reset your password:',
+            url: `${process.env.WEBSITE_URL}/auth/resetPassword?token=${token}`,
+            linkText: 'Reset Password'
+        })
+        await emailClient.sendEmail({ to: email, subject, html, text })
         res.status(200).json({
             message: 'Password reset link sent'
         })
@@ -175,6 +196,12 @@ app.post('/reset-password', async (req, res) => {
     const { token, password } = req.body
 
     try {
+        if (!token || !password) {
+            return res.status(400).json({
+                message: 'Token and password are required'
+            })
+        }
+
         // Find the user by the token and ensure it hasn't expired
         const user = await User.findOne({
             resetPasswordToken: token,
@@ -218,6 +245,12 @@ app.post('/verify', async (req, res) => {
     const { token } = req.body
 
     try {
+        if (!token) {
+            return res.status(400).json({
+                message: 'Token is required'
+            })
+        }
+
         // Find the user by the token and check if it hasn't expired
         const user = await User.findOne({ verificationToken: token })
 

--- a/services/emailClient.js
+++ b/services/emailClient.js
@@ -53,4 +53,37 @@ const sendEmail = async ({ to, subject, text, html }) => {
     }
 }
 
-module.exports = { sendEmail }
+const buildEmail = ({ header, firstName, description, url, linkText }) => {
+    const html = `
+        <html>
+            <head>
+                <style>
+                    body { font-family: Arial, sans-serif; line-height: 1.5; color: #333; }
+                    .container { max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 8px; }
+                    .button { background-color: #9E1B32; color: white !important; padding: 10px 20px; text-decoration: none; border-radius: 5px; display: inline-block; }
+                    .footer { font-size: 12px; color: #777; margin-top: 20px; }
+                </style>
+            </head>
+            <body>
+                <div class="container">
+                    <h2>${header}</h2>
+                    <p>Hello ${firstName},</p>
+                    <p>${description}</p>
+                    <p><a class="button" href="${url}">${linkText}</a></p>
+                    <p class="footer">If you did not request this, you can ignore this email.</p>
+                </div>
+            </body>
+        </html>`
+
+    const text = `Hello ${firstName},
+
+${description}
+
+${url}
+
+If you did not request this, you can ignore this email.`
+
+    return { text, html }
+}
+
+module.exports = { sendEmail, buildEmail }

--- a/services/emailClient.js
+++ b/services/emailClient.js
@@ -58,19 +58,28 @@ const buildEmail = ({ header, firstName, description, url, linkText }) => {
         <html>
             <head>
                 <style>
-                    body { font-family: Arial, sans-serif; line-height: 1.5; color: #333; }
-                    .container { max-width: 600px; margin: 0 auto; padding: 20px; border: 1px solid #ddd; border-radius: 8px; }
-                    .button { background-color: #9E1B32; color: white !important; padding: 10px 20px; text-decoration: none; border-radius: 5px; display: inline-block; }
-                    .footer { font-size: 12px; color: #777; margin-top: 20px; }
+                    body { font-family: Arial, sans-serif; line-height: 1.6; color: #333; background-color: #f4f4f4; padding: 20px; text-align: center; }
+                    .container { max-width: 600px; margin: 0 auto; padding: 20px; background: white; border-radius: 8px; box-shadow: 0 2px 10px rgba(0, 0, 0, 0.1); }
+                    .header { display: flex; align-items: center; justify-content: center; gap: 10px; }
+                    .logo { max-width: 50px; height: auto; }
+                    .button { background-color: #9E1B32; color: white !important; padding: 12px 20px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold; margin-top: 10px; }
+                    .footer { font-size: 12px; color: #777; margin-top: 20px; border-top: 1px solid #ddd; padding-top: 10px; }
+                    .footer a { color: #9E1B32; text-decoration: none; font-weight: bold; }
                 </style>
             </head>
             <body>
                 <div class="container">
-                    <h2>${header}</h2>
-                    <p>Hello ${firstName},</p>
-                    <p>${description}</p>
-                    <p><a class="button" href="${url}">${linkText}</a></p>
-                    <p class="footer">If you did not request this, you can ignore this email.</p>
+                    <div class="header">
+                        <img class="logo" src="${process.env.WEBSITE_URL}/assets/MealMatchLogoIcon.png" alt="Company Logo">
+                        <h2>${header}</h2>
+                    </div>
+                    <div class="content">
+                        <p>Hello ${firstName},</p>
+                        <p>${description}</p>
+                        <p><a class="button" href="${url}">${linkText}</a></p>
+                    </div>
+                    <p class="footer">If you did not request this, you can ignore this email.<br>
+                    For more information, visit our <a href="${process.env.WEBSITE_URL}">website</a>.</p>
                 </div>
             </body>
         </html>`
@@ -81,7 +90,9 @@ ${description}
 
 ${url}
 
-If you did not request this, you can ignore this email.`
+If you did not request this, you can ignore this email.
+
+For more information, visit our website: ${process.env.WEBSITE_URL}`
 
     return { text, html }
 }


### PR DESCRIPTION
- Modify `POST /auth/verify` and `POST /auth/reset-password` to work with the website
- Make the link sent in `POST /auth/send-reset` point towards the website rather than the app
- Make `POST /payout/account-link` work either from the app (via authenticated session) or the website (via token)
- Enhance the email client with a fancier HTML template
- Make sure that emails get stored in the database in lower case