### PR TITLE
Disputed orders API

### DIFF
--- a/models/order.js
+++ b/models/order.js
@@ -79,6 +79,14 @@ const OrderSchema = new mongoose.Schema({
         type: Date,
         required: false
     },
+    disputeTime: {
+        type: Date,
+        required: false
+    },
+    disputeReason: {
+        type: String,
+        required: false
+    },
     receiptImage: {
         type: String,
         required: false

--- a/routes/orderRoutes.js
+++ b/routes/orderRoutes.js
@@ -393,6 +393,9 @@ app.patch('/:id/dispute', isAuthenticated, async (req, res) => {
             })
         }
 
+        // TODO: send email to seller
+        // TODO: send email to admin
+
         order.status = 'Disputed'
         order.disputeTime = new Date()
         order.disputeReason = reason

--- a/routes/orderRoutes.js
+++ b/routes/orderRoutes.js
@@ -380,6 +380,19 @@ app.patch('/:id/dispute', isAuthenticated, async (req, res) => {
             })
         }
 
+        // Send notification to seller
+        const seller = await User.findById(order.seller.toString(), 'pushToken')
+        if (seller?.pushToken) {
+            expoClient.queueNotification({
+                to: seller.pushToken,
+                title: 'Order Disputed',
+                body: `Your order from ${order.restaurant} has been disputed by the buyer. We will review the issue and get back to you soon. Your payment will be held until the issue is resolved.`,
+                data: {
+                    route: `/openOrders/${order._id}`
+                }
+            })
+        }
+
         order.status = 'Disputed'
         order.disputeTime = new Date()
         order.disputeReason = reason

--- a/services/emailClient.js
+++ b/services/emailClient.js
@@ -54,7 +54,7 @@ const sendEmail = async ({ to, subject, text, html }) => {
 }
 
 const buildEmail = ({ header, firstName, description, url, linkText }) => {
-    const html = `
+    let html = `
         <html>
             <head>
                 <style>
@@ -75,24 +75,29 @@ const buildEmail = ({ header, firstName, description, url, linkText }) => {
                     </div>
                     <div class="content">
                         <p>Hello ${firstName},</p>
-                        <p>${description}</p>
-                        <p><a class="button" href="${url}">${linkText}</a></p>
-                    </div>
-                    <p class="footer">If you did not request this, you can ignore this email.<br>
-                    For more information, visit our <a href="${process.env.WEBSITE_URL}">website</a>.</p>
-                </div>
-            </body>
-        </html>`
+                        <p>${description}</p>`
+    if (url) {
+        html += `<p><a class="button" href="${url}">${linkText}</a></p>`
+    }
+    html += '</div>'
+    if (url) {
+        html += `<p class="footer">If you did not request this, you can ignore this email.<br>
+            For more information, visit our <a href="${process.env.WEBSITE_URL}">website</a>.</p>
+        </div>`
+    }
+    html += '</body></html>'
 
-    const text = `Hello ${firstName},
+    let text = `Hello ${firstName},
 
-${description}
+${description}`
 
-${url}
+    if (url) {
+        text += `${url}
 
 If you did not request this, you can ignore this email.
 
 For more information, visit our website: ${process.env.WEBSITE_URL}`
+    }
 
     return { text, html }
 }


### PR DESCRIPTION
- Add `PATCH /orders/:id/dispute` to dispute an order, with a reason
- Make `GET /orders/open` only fetch orders that are not `Completed`
- Modify `emailClient` to support building emails with & without links