### PR TITLE
Limit each IP to 100 requests per 5 minutes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
                 "dotenv": "^16.4.7",
                 "expo-server-sdk": "^3.13.0",
                 "express": "^4.21.2",
+                "express-rate-limit": "^7.5.0",
                 "express-session": "^1.18.0",
                 "googleapis": "^144.0.0",
                 "mongoose": "^8.9.5",
@@ -1636,6 +1637,21 @@
             "funding": {
                 "type": "opencollective",
                 "url": "https://opencollective.com/express"
+            }
+        },
+        "node_modules/express-rate-limit": {
+            "version": "7.5.0",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-7.5.0.tgz",
+            "integrity": "sha512-eB5zbQh5h+VenMPM3fh+nw1YExi5nMr6HUCR62ELSP11huvxm/Uir1H1QEyTkk5QX6A58pX6NmaTMceKZ0Eodg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/express-rate-limit"
+            },
+            "peerDependencies": {
+                "express": "^4.11 || 5 || ^5.0.0-beta.1"
             }
         },
         "node_modules/express-session": {

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
         "dotenv": "^16.4.7",
         "expo-server-sdk": "^3.13.0",
         "express": "^4.21.2",
+        "express-rate-limit": "^7.5.0",
         "express-session": "^1.18.0",
         "googleapis": "^144.0.0",
         "mongoose": "^8.9.5",

--- a/server.js
+++ b/server.js
@@ -3,6 +3,7 @@ const dotenv = require('dotenv')
 const express = require('express')
 const MongoStore = require('connect-mongo')
 const session = require('express-session')
+const rateLimit = require('express-rate-limit')
 
 const app = express()
 app.use(express.json())
@@ -54,6 +55,17 @@ app.use(
             secure: process.env.ENVIRONMENT === 'prod', // Use secure cookies in production
             maxAge: 1000 * 60 * 60 * 24 // Session expires in 1 day
         }
+    })
+)
+
+// Configure rate limiting
+app.use(
+    rateLimit({
+        windowMs: 5 * 60 * 1000, // 5 minutes
+        max: 100, // Limit each IP to 100 requests per windowMs
+        message: 'Too many requests from this IP, please try again later.',
+        standardHeaders: true, // Return rate limit info in `RateLimit-*` headers
+        legacyHeaders: false // Disable the `X-RateLimit-*` headers
     })
 )
 


### PR DESCRIPTION
Use [express-rate-limit](https://www.npmjs.com/package/express-rate-limit) to limit each IP address to a maximum of 100 requests per 5 minutes. We may adjust this value later on, as needed.