### PR TITLE
Notify the buyer when their order ought to be ready

### DIFF
--- a/models/order.js
+++ b/models/order.js
@@ -60,12 +60,8 @@ const OrderSchema = new mongoose.Schema({
         default: 'Pending'
     },
     readyTime: {
-        type: String,
-        required: false,
-        match: [
-            /^(0?[1-9]|1[0-2]):[0-5]\d\s?[APap][Mm]$/,
-            'Invalid time format. Use "9:34 AM" or "11:57 PM".'
-        ]
+        type: Date,
+        required: false
     },
     confirmationTime: {
         type: Date,
@@ -94,6 +90,11 @@ const OrderSchema = new mongoose.Schema({
     sellerName: {
         type: String,
         required: false
+    },
+    readyNotified: {
+        type: Boolean,
+        required: false,
+        default: false
     }
 })
 

--- a/services/mongooseClient.js
+++ b/services/mongooseClient.js
@@ -14,6 +14,9 @@ mongooseClient.connect = async (mongoUrl) => {
         // Check for seller timeouts every ten seconds
         setInterval(intervals.sellerTimeout, 10 * 1000)
 
+        // Check for order ready notifications every minute
+        setInterval(intervals.sendReadyNotifications, 60 * 1000)
+
         // Check for queued notifications every ten seconds
         setInterval(intervals.sendNotifications, 10 * 1000)
 

--- a/utils/timeUtils.js
+++ b/utils/timeUtils.js
@@ -1,0 +1,9 @@
+const formatTime = (date) => {
+    return date.toLocaleTimeString('en-US', {
+        hour: 'numeric',
+        minute: 'numeric',
+        hour12: true
+    })
+}
+
+module.exports = { formatTime }


### PR DESCRIPTION
- Notify the buyer when their order's `readyTime` has been reached
- Handle `readyTime` as a `Date` rather than a `String`
- Make sure that buyers can't claim their own orders, except in dev mode
- Add the restaurant name to most of the notifications we send out, just to be more specific
- Only retrieve specific fields from MongoDB within `intervalClient`